### PR TITLE
Files to generate new veto readout after veto system changes

### DIFF
--- a/generation/vetos/Muons.rml
+++ b/generation/vetos/Muons.rml
@@ -14,10 +14,10 @@ Author: Luis Obis (lobis@unizar.es)
         <parameter name="seed" value="17022"/>
         <parameter name="nRequestedEntries" value="1"/>
 
-        <generator type="cosmic">
+        <generator type="point" position="(0,0,0)" units="mm" >
             <source particle="mu-">
-                <energy type="formula2" name="CosmicMuons" nPoints="10000"/>
-                <angular type="formula2" direction="(0,-1,0)"/>
+                <energy type="mono" energy="10" units="GeV" />
+                <angular type="flux" direction="(0,1,0)" />
             </source>
         </generator>
 

--- a/generation/vetos/Muons.rml
+++ b/generation/vetos/Muons.rml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+Author: Luis Obis (lobis@unizar.es)
+-->
+
+<restG4>
+    <TRestRun title="CosmicMuons">
+        <parameter name="experimentName" value="IAXO"/>
+    </TRestRun>
+
+    <TRestGeant4Metadata>
+        <parameter name="gdmlFile" value="setup.gdml"/>
+        <parameter name="seed" value="17022"/>
+        <parameter name="nRequestedEntries" value="1"/>
+
+        <generator type="cosmic">
+            <source particle="mu-">
+                <energy type="formula2" name="CosmicMuons" nPoints="10000"/>
+                <angular type="formula2" direction="(0,-1,0)"/>
+            </source>
+        </generator>
+
+        <detector>
+            <parameter name="maxStepSize" value="1mm"/>
+            <removeUnwantedTracks enabled="true" keepZeroEnergyTracks="true"/>
+
+            <volume name="gasVolume" sensitive="true" maxStepSize="0.05mm"/>
+            <volume name="^scintillatorVolume" sensitive="false" keepTracks="true" maxStepSize="0.5mm"/>
+            <volume name="^captureLayerVolume" sensitive="false" keepTracks="true" maxStepSize="0.05mm"/>
+            <volume name="ShieldingVolume" sensitive="false" maxStepSize="5mm"/>
+        </detector>
+    </TRestGeant4Metadata>
+
+    <TRestGeant4PhysicsLists>
+        <parameter name="cutForGamma" value="1" units="mm"/>
+        <parameter name="cutForElectron" value="1" units="mm"/>
+        <parameter name="cutForPositron" value="1" units="mm"/>
+        <parameter name="cutForMuon" value="1" units="mm"/>
+        <parameter name="cutForNeutron" value="1" units="mm"/>
+
+        <parameter name="minEnergyRangeProductionCuts" value="1" units="keV"/>
+        <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
+
+        <physicsList name="G4EmLivermorePhysics">
+            <option name="pixe" value="false"/>
+        </physicsList>
+
+        <physicsList name="G4HadronElasticPhysicsHP"/>
+        <physicsList name="G4IonBinaryCascadePhysics"/>
+        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"/>
+        <physicsList name="G4EmExtraPhysics"/>
+
+        <physicsList name="G4DecayPhysics"/>
+        <physicsList name="G4RadioactiveDecayPhysics"/>
+        <physicsList name="G4RadioactiveDecay">
+            <option name="ICM" value="true"/>
+            <option name="ARM" value="true"/>
+        </physicsList>
+
+        <!--
+        <physicsList name="G4NeutronTrackingCut"/>
+         -->
+
+    </TRestGeant4PhysicsLists>
+</restG4>

--- a/generation/vetos/setup.gdml
+++ b/generation/vetos/setup.gdml
@@ -1,0 +1,1029 @@
+<?xml version='1.0'?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+    <define/>
+    <materials>
+        <isotope Z="29.0" N="63" name="Cu63">
+            <atom value="62.9296" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="29.0" N="65" name="Cu65">
+            <atom value="64.9278" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="6.0" N="12" name="C12">
+            <atom value="12.0" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="6.0" N="13" name="C13">
+            <atom value="13.0034" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="9.0" N="19" name="F19">
+            <atom value="18.9984" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="1.0" N="1" name="H1">
+            <atom value="1.007825" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="1.0" N="2" name="H2">
+            <atom value="2.014102" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="7.0" N="14" name="N14">
+            <atom value="14.0031" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="7.0" N="15" name="N15">
+            <atom value="15.0001" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="16" name="O16">
+            <atom value="15.9949" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="17" name="O17">
+            <atom value="16.9991" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="18" name="O18">
+            <atom value="17.9992" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="36" name="Ar36">
+            <atom value="35.9675" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="38" name="Ar38">
+            <atom value="37.9627" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="40" name="Ar40">
+            <atom value="39.9624" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="204" name="Pb204">
+            <atom value="203.973" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="206" name="Pb206">
+            <atom value="205.974" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="207" name="Pb207">
+            <atom value="206.976" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="208" name="Pb208">
+            <atom value="207.977" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="106" name="Cd106">
+            <atom value="105.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="108" name="Cd108">
+            <atom value="107.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="110" name="Cd110">
+            <atom value="109.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="111" name="Cd111">
+            <atom value="110.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="112" name="Cd112">
+            <atom value="111.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="113" name="Cd113">
+            <atom value="112.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="114" name="Cd114">
+            <atom value="113.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="116" name="Cd116">
+            <atom value="115.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="17.0" N="35" name="Cl35">
+            <atom value="34.9689" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="17.0" N="37" name="Cl37">
+            <atom value="36.9659" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cu">
+            <fraction n="0.6917" ref="Cu63"/>
+            <fraction n="0.3083" ref="Cu65"/>
+        </element>
+        <element name="C">
+            <fraction n="0.9893" ref="C12"/>
+            <fraction n="0.0107" ref="C13"/>
+        </element>
+        <element name="F">
+            <fraction n="1.0" ref="F19"/>
+        </element>
+        <element name="H">
+            <fraction n="0.999885" ref="H1"/>
+            <fraction n="1.15E-4" ref="H2"/>
+        </element>
+        <element name="N">
+            <fraction n="0.99632" ref="N14"/>
+            <fraction n="0.00368" ref="N15"/>
+        </element>
+        <element name="O">
+            <fraction n="0.99757" ref="O16"/>
+            <fraction n="3.8E-4" ref="O17"/>
+            <fraction n="0.00205" ref="O18"/>
+        </element>
+        <element name="Ar">
+            <fraction n="0.003365" ref="Ar36"/>
+            <fraction n="6.32E-4" ref="Ar38"/>
+            <fraction n="0.996003" ref="Ar40"/>
+        </element>
+        <element name="Pb">
+            <fraction n="0.014" ref="Pb204"/>
+            <fraction n="0.241" ref="Pb206"/>
+            <fraction n="0.221" ref="Pb207"/>
+            <fraction n="0.524" ref="Pb208"/>
+        </element>
+        <element name="Cd">
+            <fraction n="0.0125" ref="Cd106"/>
+            <fraction n="0.0089" ref="Cd108"/>
+            <fraction n="0.1249" ref="Cd110"/>
+            <fraction n="0.128" ref="Cd111"/>
+            <fraction n="0.2413" ref="Cd112"/>
+            <fraction n="0.1222" ref="Cd113"/>
+            <fraction n="0.2873" ref="Cd114"/>
+            <fraction n="0.0749" ref="Cd116"/>
+        </element>
+        <element name="Cl">
+            <fraction n="0.7578" ref="Cl35"/>
+            <fraction n="0.2422" ref="Cl37"/>
+        </element>
+        <material state="solid" name="G4_Cu">
+            <D value="8.96" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cu"/>
+        </material>
+        <material state="solid" name="G4_TEFLON">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="0.240179" ref="C"/>
+            <fraction n="0.759821" ref="F"/>
+        </material>
+        <material state="solid" name="G4_KAPTON">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.691128" ref="C"/>
+            <fraction n="0.026363" ref="H"/>
+            <fraction n="0.073271" ref="N"/>
+            <fraction n="0.209237" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MYLAR">
+            <D value="1.4" unit="g/cm3"/>
+            <fraction n="0.625011" ref="C"/>
+            <fraction n="0.041961" ref="H"/>
+            <fraction n="0.333028" ref="O"/>
+        </material>
+        <material state="gas" name="G4_Galactic">
+            <D value="1.0E-22" unit="kg/m3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="gas" name="GasMixture-Argon2%Isobutane1.4Bar">
+            <D value="2.319820104" unit="kg/m3"/>
+            <fraction n="0.98" ref="Ar"/>
+            <fraction n="0.016532" ref="C"/>
+            <fraction n="0.003468" ref="H"/>
+        </material>
+        <material state="solid" name="G4_Pb">
+            <D value="11.35" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pb"/>
+        </material>
+        <material state="solid" name="BC408">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.085" ref="H"/>
+            <fraction n="0.915" ref="C"/>
+        </material>
+        <material state="solid" name="G4_Cd">
+            <D value="8.65" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cd"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_NEOPRENE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.05692" ref="H"/>
+            <fraction n="0.542646" ref="C"/>
+            <fraction n="0.400434" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_LUCITE">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.080538" ref="H"/>
+            <fraction n="0.599848" ref="C"/>
+            <fraction n="0.319614" ref="O"/>
+        </material>
+        <material state="gas" name="G4_AIR">
+            <D value="1.20479" unit="kg/m3"/>
+            <fraction n="1.24E-4" ref="C"/>
+            <fraction n="0.755268" ref="N"/>
+            <fraction n="0.231781" ref="O"/>
+            <fraction n="0.012827" ref="Ar"/>
+        </material>
+    </materials>
+    <solids>
+        <box lunit="mm" aunit="rad" name="chamberBodyBaseSolid" x="134.0" y="134.0" z="30.0"/>
+        <tube lunit="mm" aunit="rad" name="chamberBodyHoleSolid" rmax="51.0" z="30.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="chamberBodySolid">
+            <first ref="chamberBodyBaseSolid"/>
+            <second ref="chamberBodyHoleSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="chamberBackplateSolid" x="134.0" y="134.0" z="15.0"/>
+        <tube lunit="mm" aunit="rad" name="chamberTeflonWallSolid" rmax="51.0" z="30.0" rmin="50.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <box lunit="mm" aunit="rad" name="kaptonReadoutSolid" x="134.0" y="134.0" z="0.5"/>
+        <box lunit="mm" aunit="rad" name="copperReadoutSolid" x="60.0" y="60.0" z="0.2"/>
+        <tube lunit="mm" aunit="rad" name="cathodeTeflonDiskBaseSolid" rmax="67.0" z="5.0" rmin="15.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="cathodeCopperDiskSolid" rmax="45.0" z="1.0" rmin="8.5" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodeTeflonDiskSolid">
+            <position name="cathodeTeflonDiskSolid.position" z="-2.0" unit="mm"/>
+            <first ref="cathodeTeflonDiskBaseSolid"/>
+            <second ref="cathodeCopperDiskSolid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="cathodeWindowSolid" rmax="15.0" z="0.004" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <box lunit="mm" aunit="rad" name="cathodePatternLineAux" x="0.3" y="17.0" z="1.0"/>
+        <tube lunit="mm" aunit="rad" name="cathodePatternCentralHole" rmax="4.25" z="1.1" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodePatternLine">
+            <first ref="cathodePatternLineAux"/>
+            <second ref="cathodePatternCentralHole"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="cathodePatternDisk" rmax="4.25" z="1.0" rmin="3.95" startphi="0.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux0">
+            <rotation name="cathodeCopperDiskSolidAux0.rotation" unit="deg"/>
+            <first ref="cathodeCopperDiskSolid"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux1">
+            <rotation name="cathodeCopperDiskSolidAux1.rotation" z="45.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux0"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux2">
+            <rotation name="cathodeCopperDiskSolidAux2.rotation" z="90.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux1"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskSolidAux3">
+            <rotation name="cathodeCopperDiskSolidAux3.rotation" z="135.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux2"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="cathodeCopperDiskFinal.solid">
+            <first ref="cathodeCopperDiskSolidAux3"/>
+            <second ref="cathodePatternDisk"/>
+        </union>
+        <tube lunit="mm" aunit="rad" name="cathodeFillingBaseSolid" rmax="15.0" z="5.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="cathodeFillingSolid">
+            <position name="cathodeFillingSolid.position" z="-2.0" unit="mm"/>
+            <first ref="cathodeFillingBaseSolid"/>
+            <second ref="cathodeCopperDiskFinal.solid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="gasSolidOriginal" rmax="50.0" z="30.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction lunit="mm" aunit="rad" name="gasSolidAux">
+            <position name="gasSolidAux.position" z="-14.9" unit="mm"/>
+            <rotation name="gasSolidAux.rotation" z="45.0" unit="deg"/>
+            <first ref="gasSolidOriginal"/>
+            <second ref="copperReadoutSolid"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="gasSolid">
+            <position name="gasSolid.position" z="14.998" unit="mm"/>
+            <first ref="gasSolidAux"/>
+            <second ref="cathodeWindowSolid"/>
+        </subtraction>
+        <tube lunit="mm" aunit="rad" name="detectorPipeChamberFlangeSolid" rmax="67.0" z="14.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeTelescopeFlangeSolid" rmax="75.0" z="18.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeSection1of2Solid" rmax="46.0" z="327.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeSection2of2Solid" rmax="54.0" z="132.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="detectorPipeAux1">
+            <position name="detectorPipeAux1.position" z="170.5" unit="mm"/>
+            <first ref="detectorPipeChamberFlangeSolid"/>
+            <second ref="detectorPipeSection1of2Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeAux2">
+            <position name="detectorPipeAux2.position" z="400.0" unit="mm"/>
+            <first ref="detectorPipeAux1"/>
+            <second ref="detectorPipeSection2of2Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeNotEmpty">
+            <position name="detectorPipeNotEmpty.position" z="475.0" unit="mm"/>
+            <first ref="detectorPipeAux2"/>
+            <second ref="detectorPipeTelescopeFlangeSolid"/>
+        </union>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside1of3Solid" rmax="21.5" z="179.35" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside2of3Solid" rmax="34.0" z="160.28" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <tube lunit="mm" aunit="rad" name="detectorPipeInside3of3Solid" rmax="42.5" z="106.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone1of3Solid" z="21.65" rmax1="21.5" rmax2="34.0" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone2of3Solid" z="14.72" rmax1="34.0" rmax2="42.5" deltaphi="6.283185307179586"/>
+        <cone lunit="mm" aunit="rad" name="detectorPipeInsideCone3of3Solid" z="9.0" rmax1="42.5" rmax2="54.0" deltaphi="6.283185307179586"/>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux1">
+            <position name="detectorPipeInsideAux1.position" z="100.5" unit="mm"/>
+            <first ref="detectorPipeInside1of3Solid"/>
+            <second ref="detectorPipeInsideCone1of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux2">
+            <position name="detectorPipeInsideAux2.position" z="191.465" unit="mm"/>
+            <first ref="detectorPipeInsideAux1"/>
+            <second ref="detectorPipeInside2of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux3">
+            <position name="detectorPipeInsideAux3.position" z="191.465" unit="mm"/>
+            <first ref="detectorPipeInsideAux2"/>
+            <second ref="detectorPipeInsideCone2of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInsideAux4">
+            <position name="detectorPipeInsideAux4.position" z="251.82500000000002" unit="mm"/>
+            <first ref="detectorPipeInsideAux3"/>
+            <second ref="detectorPipeInside3of3Solid"/>
+        </union>
+        <union lunit="mm" aunit="rad" name="detectorPipeInside">
+            <position name="detectorPipeInside.position" z="309.32500000000005" unit="mm"/>
+            <first ref="detectorPipeInsideAux4"/>
+            <second ref="detectorPipeInsideCone3of3Solid"/>
+        </union>
+        <subtraction lunit="mm" aunit="rad" name="detectorPipeSolid">
+            <position name="detectorPipeSolid.position" z="82.675" unit="mm"/>
+            <first ref="detectorPipeNotEmpty"/>
+            <second ref="detectorPipeInside"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="leadBoxSolid" x="590.0" y="590.0" z="540.0"/>
+        <box lunit="mm" aunit="rad" name="leadBoxShaftSolid" x="194.0" y="170.0" z="340.0"/>
+        <subtraction lunit="mm" aunit="rad" name="leadBoxWithShaftSolid">
+            <position name="leadBoxWithShaftSolid.position" z="100.0" unit="mm"/>
+            <first ref="leadBoxSolid"/>
+            <second ref="leadBoxShaftSolid"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="scintillatorSolid-1500.0mm" x="200.0" y="50.0" z="1500.0"/>
+        <box lunit="mm" aunit="rad" name="captureLayerSolid-1500.0mm" x="200.0" y="1.0" z="1500.0"/>
+        <box lunit="mm" aunit="rad" name="scintillatorWrappingBaseSolid-1500.0mm" x="202.0" y="52.0" z="1502.0"/>
+        <box lunit="mm" aunit="rad" name="scintillatorWrappingHoleSolid-1500.0mm" x="200.0" y="50.0" z="1500.0"/>
+        <subtraction lunit="mm" aunit="rad" name="scintillatorWrappingFullSolid-1500.0mm">
+            <first ref="scintillatorWrappingBaseSolid-1500.0mm"/>
+            <second ref="scintillatorWrappingHoleSolid-1500.0mm"/>
+        </subtraction>
+        <box lunit="mm" aunit="rad" name="scintillatorWrappingRemoveSideSolid" x="202.0" y="52.0" z="1.2"/>
+        <subtraction lunit="mm" aunit="rad" name="scintillatorWrappingSolid-1500.0mm.solid">
+            <position name="scintillatorWrappingSolid-1500.0mm.solid.position" z="-750.5" unit="mm"/>
+            <first ref="scintillatorWrappingFullSolid-1500.0mm"/>
+            <second ref="scintillatorWrappingRemoveSideSolid"/>
+        </subtraction>
+        <trd lunit="mm" aunit="rad" name="scintillatorLightGuide1Solid-1500.0mm" x1="200.0" x2="200.0" y1="60.0" y2="50.0" z="130.0"/>
+        <trd lunit="mm" aunit="rad" name="scintillatorLightGuide2Solid-1500.0mm" x1="70.0" x2="200.0" y1="70.0" y2="60.0" z="80.0"/>
+        <union lunit="mm" aunit="rad" name="scintillatorLightGuideSolid-1500.0mm">
+            <position name="scintillatorLightGuideSolid-1500.0mm.position" z="-105.0" unit="mm"/>
+            <first ref="scintillatorLightGuide1Solid-1500.0mm"/>
+            <second ref="scintillatorLightGuide2Solid-1500.0mm"/>
+        </union>
+        <box lunit="mm" aunit="rad" name="scintillatorSolid-800.0mm" x="200.0" y="50.0" z="800.0"/>
+        <box lunit="mm" aunit="rad" name="captureLayerSolid-800.0mm" x="200.0" y="1.0" z="800.0"/>
+        <box lunit="mm" aunit="rad" name="scintillatorWrappingBaseSolid-800.0mm" x="202.0" y="52.0" z="802.0"/>
+        <box lunit="mm" aunit="rad" name="scintillatorWrappingHoleSolid-800.0mm" x="200.0" y="50.0" z="800.0"/>
+        <subtraction lunit="mm" aunit="rad" name="scintillatorWrappingFullSolid-800.0mm">
+            <first ref="scintillatorWrappingBaseSolid-800.0mm"/>
+            <second ref="scintillatorWrappingHoleSolid-800.0mm"/>
+        </subtraction>
+        <subtraction lunit="mm" aunit="rad" name="scintillatorWrappingSolid-800.0mm.solid">
+            <position name="scintillatorWrappingSolid-800.0mm.solid.position" z="-400.5" unit="mm"/>
+            <first ref="scintillatorWrappingFullSolid-800.0mm"/>
+            <second ref="scintillatorWrappingRemoveSideSolid"/>
+        </subtraction>
+        <trd lunit="mm" aunit="rad" name="scintillatorLightGuide1Solid-800.0mm" x1="200.0" x2="200.0" y1="60.0" y2="50.0" z="130.0"/>
+        <trd lunit="mm" aunit="rad" name="scintillatorLightGuide2Solid-800.0mm" x1="70.0" x2="200.0" y1="70.0" y2="60.0" z="80.0"/>
+        <union lunit="mm" aunit="rad" name="scintillatorLightGuideSolid-800.0mm">
+            <position name="scintillatorLightGuideSolid-800.0mm.position" z="-105.0" unit="mm"/>
+            <first ref="scintillatorLightGuide1Solid-800.0mm"/>
+            <second ref="scintillatorLightGuide2Solid-800.0mm"/>
+        </union>
+        <box lunit="mm" aunit="rad" name="worldBox" x="1350.0" y="1350.0" z="3000.0"/>
+    </solids>
+    <structure>
+        <volume name="chamberBodyVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="chamberBodySolid"/>
+        </volume>
+        <volume name="chamberBackplateVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="chamberBackplateSolid"/>
+        </volume>
+        <volume name="chamberTeflonWallVolume">
+            <materialref ref="G4_TEFLON"/>
+            <solidref ref="chamberTeflonWallSolid"/>
+        </volume>
+        <volume name="kaptonReadoutVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="kaptonReadoutSolid"/>
+        </volume>
+        <volume name="copperReadoutVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="copperReadoutSolid"/>
+        </volume>
+        <volume name="cathodeTeflonDiskVolume">
+            <materialref ref="G4_TEFLON"/>
+            <solidref ref="cathodeTeflonDiskSolid"/>
+        </volume>
+        <volume name="cathodeWindowVolume">
+            <materialref ref="G4_MYLAR"/>
+            <solidref ref="cathodeWindowSolid"/>
+        </volume>
+        <volume name="cathodeCopperDiskFinal">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="cathodeCopperDiskFinal.solid"/>
+        </volume>
+        <volume name="cathodeFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="cathodeFillingSolid"/>
+        </volume>
+        <volume name="gasVolume">
+            <materialref ref="GasMixture-Argon2%Isobutane1.4Bar"/>
+            <solidref ref="gasSolid"/>
+        </volume>
+        <assembly name="Chamber">
+            <physvol name="gas">
+                <volumeref ref="gasVolume"/>
+            </physvol>
+            <physvol name="chamberBackplate">
+                <volumeref ref="chamberBackplateVolume"/>
+                <position name="chamberBackplate.position" z="-23.0" unit="mm"/>
+            </physvol>
+            <physvol name="chamberBody">
+                <volumeref ref="chamberBodyVolume"/>
+            </physvol>
+            <physvol name="chamberTeflonWall">
+                <volumeref ref="chamberTeflonWallVolume"/>
+            </physvol>
+            <physvol name="kaptonReadout">
+                <volumeref ref="kaptonReadoutVolume"/>
+                <position name="kaptonReadout.position" z="-15.25" unit="mm"/>
+            </physvol>
+            <physvol name="copperReadout">
+                <volumeref ref="copperReadoutVolume"/>
+                <position name="copperReadout.position" z="-14.9" unit="mm"/>
+                <rotation name="copperReadout.rotation" z="45.0" unit="deg"/>
+            </physvol>
+            <physvol name="cathodeWindow">
+                <volumeref ref="cathodeWindowVolume"/>
+                <position name="cathodeWindow.position" z="14.998" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeTeflonDisk">
+                <volumeref ref="cathodeTeflonDiskVolume"/>
+                <position name="cathodeTeflonDisk.position" z="17.5" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeFilling">
+                <volumeref ref="cathodeFillingVolume"/>
+                <position name="cathodeFilling.position" z="17.5" unit="mm"/>
+            </physvol>
+            <physvol name="cathodeCopperDiskPattern">
+                <volumeref ref="cathodeCopperDiskFinal"/>
+                <position name="cathodeCopperDiskPattern.position" z="15.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="detectorPipeVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="detectorPipeSolid"/>
+        </volume>
+        <volume name="detectorPipeFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="detectorPipeInside"/>
+        </volume>
+        <assembly name="DetectorPipe">
+            <physvol name="detectorPipe">
+                <volumeref ref="detectorPipeVolume"/>
+            </physvol>
+            <physvol name="detectorPipeFilling">
+                <volumeref ref="detectorPipeFillingVolume"/>
+                <position name="detectorPipeFilling.position" z="82.675" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="ShieldingVolume">
+            <materialref ref="G4_Pb"/>
+            <solidref ref="leadBoxWithShaftSolid"/>
+        </volume>
+        <assembly name="Shielding">
+            <physvol name="shielding20cm">
+                <volumeref ref="ShieldingVolume"/>
+                <position name="shielding20cm.position" z="29.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="scintillatorVolume-1500.0mm">
+            <materialref ref="BC408"/>
+            <solidref ref="scintillatorSolid-1500.0mm"/>
+        </volume>
+        <volume name="captureLayerVolume-1500.0mm">
+            <materialref ref="G4_Cd"/>
+            <solidref ref="captureLayerSolid-1500.0mm"/>
+        </volume>
+        <volume name="scintillatorWrappingSolid-1500.0mm">
+            <materialref ref="G4_RUBBER_NEOPRENE"/>
+            <solidref ref="scintillatorWrappingSolid-1500.0mm.solid"/>
+        </volume>
+        <volume name="scintillatorLightGuideVolume-1500.0mm">
+            <materialref ref="G4_LUCITE"/>
+            <solidref ref="scintillatorLightGuideSolid-1500.0mm"/>
+        </volume>
+        <assembly name="assembly-5">
+            <physvol name="scintillatorVolume-1500.0mm-7326620e">
+                <volumeref ref="scintillatorVolume-1500.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-1500.0mm-7326620f">
+                <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-73266210">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266210.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-73266211">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266211.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266212">
+                <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-73266212.position" z="-815.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-6">
+            <physvol name="assembly-6.veto4">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto4.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto3">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto3.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto2">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto2.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-6.veto1">
+                <volumeref ref="assembly-5"/>
+                <position name="assembly-6.veto1.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-7">
+            <physvol name="scintillatorVolume-1500.0mm-73266210">
+                <volumeref ref="scintillatorVolume-1500.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-1500.0mm-73266211">
+                <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-73266212">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266212.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-73266213">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-73266213.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-73266214">
+                <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-73266214.position" z="-815.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-8">
+            <physvol name="assembly-8.veto1">
+                <volumeref ref="assembly-7"/>
+                <position name="assembly-8.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-8.veto2">
+                <volumeref ref="assembly-7"/>
+                <position name="assembly-8.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-8.veto3">
+                <volumeref ref="assembly-7"/>
+                <position name="assembly-8.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-8.veto4">
+                <volumeref ref="assembly-7"/>
+                <position name="assembly-8.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="scintillatorVolume-800.0mm">
+            <materialref ref="BC408"/>
+            <solidref ref="scintillatorSolid-800.0mm"/>
+        </volume>
+        <volume name="captureLayerVolume-800.0mm">
+            <materialref ref="G4_Cd"/>
+            <solidref ref="captureLayerSolid-800.0mm"/>
+        </volume>
+        <volume name="scintillatorWrappingSolid-800.0mm">
+            <materialref ref="G4_RUBBER_NEOPRENE"/>
+            <solidref ref="scintillatorWrappingSolid-800.0mm.solid"/>
+        </volume>
+        <volume name="scintillatorLightGuideVolume-800.0mm">
+            <materialref ref="G4_LUCITE"/>
+            <solidref ref="scintillatorLightGuideSolid-800.0mm"/>
+        </volume>
+        <assembly name="assembly-10">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df66">
+                <volumeref ref="scintillatorVolume-800.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df67">
+                <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-800.0mm-f1a5df68">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df68.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-800.0mm-f1a5df69">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df69.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df6a">
+                <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df6a.position" z="-465.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-11">
+            <physvol name="assembly-11.veto3">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto3.position" x="-207.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto2">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-11.veto1">
+                <volumeref ref="assembly-10"/>
+                <position name="assembly-11.veto1.position" x="207.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-9">
+            <physvol name="vetoLayerTop1">
+                <volumeref ref="assembly-11"/>
+                <position name="vetoLayerTop1.position" y="-35.0" z="-240.0" unit="mm"/>
+                <rotation name="vetoLayerTop1.rotation" y="180.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerTop2">
+                <volumeref ref="assembly-8"/>
+                <position name="vetoLayerTop2.position" y="59.0" unit="mm"/>
+                <rotation name="vetoLayerTop2.rotation" y="360.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerTop3">
+                <volumeref ref="assembly-6"/>
+                <position name="vetoLayerTop3.position" y="118.0" unit="mm"/>
+                <rotation name="vetoLayerTop3.rotation" y="540.0" unit="deg"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-12">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df68">
+                <volumeref ref="scintillatorVolume-1500.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df69">
+                <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6a">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6a.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6b">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6b.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c">
+                <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6c.position" z="-815.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-13">
+            <physvol name="assembly-13.veto4">
+                <volumeref ref="assembly-12"/>
+                <position name="assembly-13.veto4.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-13.veto3">
+                <volumeref ref="assembly-12"/>
+                <position name="assembly-13.veto3.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-13.veto2">
+                <volumeref ref="assembly-12"/>
+                <position name="assembly-13.veto2.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-13.veto1">
+                <volumeref ref="assembly-12"/>
+                <position name="assembly-13.veto1.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-14">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df6a">
+                <volumeref ref="scintillatorVolume-1500.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df6b">
+                <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6c">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6c.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df6d">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df6d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df6e">
+                <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df6e.position" z="-815.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-15">
+            <physvol name="assembly-15.veto1">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto1.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto2">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto2.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto3">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto3.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-15.veto4">
+                <volumeref ref="assembly-14"/>
+                <position name="assembly-15.veto4.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-17">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df6d">
+                <volumeref ref="scintillatorVolume-800.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df6e">
+                <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-800.0mm-f1a5df6f">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df6f.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-800.0mm-f1a5df70">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df70.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df71">
+                <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df71.position" z="-465.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-18">
+            <physvol name="assembly-18.veto4">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto4.position" x="-310.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto3">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto3.position" x="-103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto2">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto2.position" x="103.5" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-18.veto1">
+                <volumeref ref="assembly-17"/>
+                <position name="assembly-18.veto1.position" x="310.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-16">
+            <physvol name="vetoLayerBottom1">
+                <volumeref ref="assembly-18"/>
+                <position name="vetoLayerBottom1.position" y="20.0" z="-350.0" unit="mm"/>
+                <rotation name="vetoLayerBottom1.rotation" y="180.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerBottom2">
+                <volumeref ref="assembly-15"/>
+                <position name="vetoLayerBottom2.position" y="-59.0" unit="mm"/>
+                <rotation name="vetoLayerBottom2.rotation" y="360.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerBottom3">
+                <volumeref ref="assembly-13"/>
+                <position name="vetoLayerBottom3.position" y="-118.0" unit="mm"/>
+                <rotation name="vetoLayerBottom3.rotation" y="540.0" unit="deg"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-19">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df6f">
+                <volumeref ref="scintillatorVolume-1500.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df70">
+                <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df71">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df71.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df72">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df72.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df73">
+                <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df73.position" z="-815.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-20">
+            <physvol name="assembly-20.veto3">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto3.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto2">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-20.veto1">
+                <volumeref ref="assembly-19"/>
+                <position name="assembly-20.veto1.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-21">
+            <physvol name="vetoLayerRight1">
+                <volumeref ref="assembly-20"/>
+                <position name="vetoLayerRight1.position" x="-0.0" unit="mm"/>
+                <rotation name="vetoLayerRight1.rotation" x="180.0" z="-90.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerRight2">
+                <volumeref ref="assembly-20"/>
+                <position name="vetoLayerRight2.position" x="-74.0" unit="mm"/>
+                <rotation name="vetoLayerRight2.rotation" x="180.0" z="-90.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerRight3">
+                <volumeref ref="assembly-20"/>
+                <position name="vetoLayerRight3.position" x="-148.0" unit="mm"/>
+                <rotation name="vetoLayerRight3.rotation" x="180.0" z="-90.0" unit="deg"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-22">
+            <physvol name="scintillatorVolume-1500.0mm-f1a5df87">
+                <volumeref ref="scintillatorVolume-1500.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-1500.0mm-f1a5df88">
+                <volumeref ref="scintillatorWrappingSolid-1500.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df89">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df89.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-1500.0mm-f1a5df8a">
+                <volumeref ref="captureLayerVolume-1500.0mm"/>
+                <position name="captureLayerVolume-1500.0mm-f1a5df8a.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-1500.0mm-f1a5df8b">
+                <volumeref ref="scintillatorLightGuideVolume-1500.0mm"/>
+                <position name="scintillatorLightGuideVolume-1500.0mm-f1a5df8b.position" z="-815.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-23">
+            <physvol name="assembly-23.veto3">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto3.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto2">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-23.veto1">
+                <volumeref ref="assembly-22"/>
+                <position name="assembly-23.veto1.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-24">
+            <physvol name="vetoLayerLeft1">
+                <volumeref ref="assembly-23"/>
+                <position name="vetoLayerLeft1.position" unit="mm"/>
+                <rotation name="vetoLayerLeft1.rotation" z="90.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerLeft2">
+                <volumeref ref="assembly-23"/>
+                <position name="vetoLayerLeft2.position" x="74.0" unit="mm"/>
+                <rotation name="vetoLayerLeft2.rotation" z="90.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerLeft3">
+                <volumeref ref="assembly-23"/>
+                <position name="vetoLayerLeft3.position" x="148.0" unit="mm"/>
+                <rotation name="vetoLayerLeft3.rotation" z="90.0" unit="deg"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-25">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df8a">
+                <volumeref ref="scintillatorVolume-800.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df8b">
+                <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-800.0mm-f1a5df8c">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df8c.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-800.0mm-f1a5df8d">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df8d.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df8e">
+                <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df8e.position" z="-465.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-26">
+            <physvol name="assembly-26.veto1">
+                <volumeref ref="assembly-25"/>
+                <position name="assembly-26.veto1.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-26.veto2">
+                <volumeref ref="assembly-25"/>
+                <position name="assembly-26.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-26.veto3">
+                <volumeref ref="assembly-25"/>
+                <position name="assembly-26.veto3.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-27">
+            <physvol name="vetoLayerBack1">
+                <volumeref ref="assembly-26"/>
+                <position name="vetoLayerBack1.position" z="-0.0" unit="mm"/>
+                <rotation name="vetoLayerBack1.rotation" x="-90.0" y="-90.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerBack2">
+                <volumeref ref="assembly-26"/>
+                <position name="vetoLayerBack2.position" z="-74.0" unit="mm"/>
+                <rotation name="vetoLayerBack2.rotation" x="-90.0" y="-90.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerBack3">
+                <volumeref ref="assembly-26"/>
+                <position name="vetoLayerBack3.position" z="-148.0" unit="mm"/>
+                <rotation name="vetoLayerBack3.rotation" x="-90.0" y="-90.0" unit="deg"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-28">
+            <physvol name="scintillatorVolume-800.0mm-f1a5df8d">
+                <volumeref ref="scintillatorVolume-800.0mm"/>
+            </physvol>
+            <physvol name="scintillatorWrappingSolid-800.0mm-f1a5df8e">
+                <volumeref ref="scintillatorWrappingSolid-800.0mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-800.0mm-f1a5df8f">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df8f.position" y="26.5" unit="mm"/>
+            </physvol>
+            <physvol name="captureLayerVolume-800.0mm-f1a5df90">
+                <volumeref ref="captureLayerVolume-800.0mm"/>
+                <position name="captureLayerVolume-800.0mm-f1a5df90.position" y="-26.5" unit="mm"/>
+            </physvol>
+            <physvol name="scintillatorLightGuideVolume-800.0mm-f1a5df91">
+                <volumeref ref="scintillatorLightGuideVolume-800.0mm"/>
+                <position name="scintillatorLightGuideVolume-800.0mm-f1a5df91.position" z="-465.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-29">
+            <physvol name="assembly-29.veto3">
+                <volumeref ref="assembly-28"/>
+                <position name="assembly-29.veto3.position" x="-212.0" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-29.veto2">
+                <volumeref ref="assembly-28"/>
+                <position name="assembly-29.veto2.position" unit="mm"/>
+            </physvol>
+            <physvol name="assembly-29.veto1">
+                <volumeref ref="assembly-28"/>
+                <position name="assembly-29.veto1.position" x="212.0" unit="mm"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-30">
+            <physvol name="vetoLayerFront1">
+                <volumeref ref="assembly-29"/>
+                <position name="vetoLayerFront1.position" unit="mm"/>
+                <rotation name="vetoLayerFront1.rotation" x="-90.0" y="90.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerFront2">
+                <volumeref ref="assembly-29"/>
+                <position name="vetoLayerFront2.position" z="74.0" unit="mm"/>
+                <rotation name="vetoLayerFront2.rotation" x="-90.0" y="90.0" unit="deg"/>
+            </physvol>
+            <physvol name="vetoLayerFront3">
+                <volumeref ref="assembly-29"/>
+                <position name="vetoLayerFront3.position" z="148.0" unit="mm"/>
+                <rotation name="vetoLayerFront3.rotation" x="-90.0" y="90.0" unit="deg"/>
+            </physvol>
+        </assembly>
+        <assembly name="assembly-4">
+            <physvol name="vetoSystemTop">
+                <volumeref ref="assembly-9"/>
+                <position name="vetoSystemTop.position" y="327.0" z="19.5" unit="mm"/>
+            </physvol>
+            <physvol name="vetoSystemBottom">
+                <volumeref ref="assembly-16"/>
+                <position name="vetoSystemBottom.position" y="-437.0" z="19.5" unit="mm"/>
+            </physvol>
+            <physvol name="vetoSystemRight">
+                <volumeref ref="assembly-21"/>
+                <position name="vetoSystemRight.position" x="-387.0" z="119.5" unit="mm"/>
+            </physvol>
+            <physvol name="vetoSystemLeft">
+                <volumeref ref="assembly-24"/>
+                <position name="vetoSystemLeft.position" x="387.0" z="-80.5" unit="mm"/>
+            </physvol>
+            <physvol name="vetoSystemBack">
+                <volumeref ref="assembly-27"/>
+                <position name="vetoSystemBack.position" x="-65.0" z="-692.5" unit="mm"/>
+            </physvol>
+            <physvol name="vetoSystemFront">
+                <volumeref ref="assembly-30"/>
+                <position name="vetoSystemFront.position" x="65.0" z="711.5" unit="mm"/>
+            </physvol>
+        </assembly>
+        <volume name="world">
+            <physvol name="Chamber">
+                <volumeref ref="Chamber"/>
+            </physvol>
+            <physvol name="DetectorPipe">
+                <volumeref ref="DetectorPipe"/>
+                <position name="DetectorPipe.position" z="27.0" unit="mm"/>
+            </physvol>
+            <physvol name="Shielding">
+                <volumeref ref="Shielding"/>
+            </physvol>
+            <physvol name="VetoSystem">
+                <volumeref ref="assembly-4"/>
+                <position name="VetoSystem.position" y="40.0" z="400.0" unit="mm"/>
+            </physvol>
+            <materialref ref="G4_AIR"/>
+            <solidref ref="worldBox"/>
+        </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+        <world ref="world"/>
+    </setup>
+</gdml>

--- a/generation/vetos/simulation.sh
+++ b/generation/vetos/simulation.sh
@@ -1,3 +1,3 @@
 
 # we need to save the geometry into a TGeoManager object to parse it
-restG4 ./Muons.rml -o simulation.root --entries 1
+restG4 Muons.rml -o simulation.root --entries 1

--- a/generation/vetos/simulation.sh
+++ b/generation/vetos/simulation.sh
@@ -1,3 +1,3 @@
 
 # we need to save the geometry into a TGeoManager object to parse it
-restG4 $REST_PATH/examples/restG4/13.IAXO/Muons.rml -o simulation.root --entries 1
+restG4 ./Muons.rml -o simulation.root --entries 1


### PR DESCRIPTION
I changed the veto system geometry here https://github.com/iaxo/iaxo-geometry/pull/14 to make it as in IAXOLab. Since each veto is a readout plane in the readout, they must be changed after the veto system change.

The readout is generated from a .root file created from a simple simulation using a given geometry. Before it used the geometry and .rml file (for the simulation) of an example, I make it so it uses a geometry and a simple .rml file inside this repository, that are changed to have the correct veto system (i dont know if adding the files to the repository is a good idea but i prefer not to change the example).